### PR TITLE
Run Next.js build and handle errors

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -10,18 +10,11 @@ const f = createUploadthing();
 export const ourFileRouter = {
   // Define as many FileRoutes as you like, each with a unique routeSlug
 
-  videoUploader: f({ 
+  videoUploader: f({
     video: { 
       maxFileSize: uploadthingConfig.maxFileSize, 
       maxFileCount: uploadthingConfig.maxFileCount 
-    } 
-
-  videoUploader: f({
-    video: { 
-      maxFileSize: "128MB", 
-      maxFileCount: 1
-    },
-
+    }
   })
     // Set permissions and file types for this FileRoute
     .middleware(async () => {


### PR DESCRIPTION
Fix syntax error in UploadThing configuration to resolve build failure.

The build was failing with a `Syntax Error: Expected ',', got 'videoUploader'` in `src/app/api/uploadthing/core.ts`. This was caused by a duplicate and malformed `videoUploader` definition. This PR removes the redundant entry and ensures the remaining `videoUploader` definition is correctly formatted, allowing the application to compile successfully.